### PR TITLE
Simplify scripts (DRY: Don’t repeat yourself)

### DIFF
--- a/apply_blueprint.sh
+++ b/apply_blueprint.sh
@@ -1,36 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-if [ -z "$CLOUD_TO_USE" ]; then
-    echo "CLOUD_TO_USE environment variable must be set to one of the following: aws, azure, gce, openstack, static"
-    exit 1
-fi
+source "${BASH_SOURCE%/*}/set_cloud.sh"
 
-cloud_to_use=$(echo "$CLOUD_TO_USE" | tr '[:upper:]' '[:lower:]')
-case $cloud_to_use in
-aws|amazon)
-  cloud_to_use=aws
-  message="Cloud to be used is AWS.\nMake sure you've set the AWS authentication variables."
-  ;;
-azure|microsoft)
-  cloud_to_use=azure
-  message="Cloud to be used is Microsoft Azure.\nMake sure $HOME/.azure/credentials exists and it's correct."
-  ;;
-gce|google|gcp)
-  cloud_to_use=gce
-  message="Cloud to be used is Google Compute Engine.\nMake sure you've set the GCE authentication variables and JSON credentials file."
-  ;;
-openstack)
-  message="Cloud to be used is OpenStack.\nMake sure you've sourced the OpenStack RC file."
-  ;;
-static)
-  message="The static inventory will be used."
-  ;;
-*)
-  message="CLOUD_TO_USE environment variable was set to \"$CLOUD_TO_USE\" but must be set to one of the following: aws, azure, gce, openstack, static"
-  echo -e $message
-  exit 1
-  ;;
-esac
-
-echo -e $message
-ansible-playbook -i inventory/$cloud_to_use -e "cloud_name=$cloud_to_use" playbooks/apply_blueprint.yml
+ansible-playbook -i "inventory/${cloud_to_use}" -e "cloud_name=${cloud_to_use}" playbooks/apply_blueprint.yml

--- a/build_cloud.sh
+++ b/build_cloud.sh
@@ -1,33 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-if [ -z "$CLOUD_TO_USE" ]; then
-    echo "CLOUD_TO_USE environment variable must be set to one of the following: aws, azure, gce, openstack"
-    exit 1
-fi
+source "${BASH_SOURCE%/*}/set_cloud.sh"
 
-cloud_to_use=$(echo "$CLOUD_TO_USE" | tr '[:upper:]' '[:lower:]')
 case $cloud_to_use in
-aws|amazon)
-  cloud_to_use=aws
-  message="Cloud to be used is AWS.\nMake sure you've set the AWS authentication variables."
-  ;;
-azure|microsoft)
-  cloud_to_use=azure
-  message="Cloud to be used is Microsoft Azure.\nMake sure $HOME/.azure/credentials exists and it's correct."
-  ;;
-gce|google|gcp)
-  cloud_to_use=gce
-  message="Cloud to be used is Google Compute Engine.\nMake sure you've set the GCE authentication variables and JSON credentials file."
-  ;;
-openstack)
-  message="Cloud to be used is OpenStack.\nMake sure you've sourced the OpenStack RC file."
+aws|azure|gce|openstack)
   ;;
 *)
-  message="CLOUD_TO_USE environment variable was set to \"$CLOUD_TO_USE\" but must be set to one of the following: aws, azure, openstack"
+  message="CLOUD_TO_USE environment variable was set to \"$CLOUD_TO_USE\" but must be set to one of the following: aws, azure, gce, openstack"
   echo -e $message
   exit 1
   ;;
 esac
 
-echo -e $message
-ansible-playbook -i inventory/localhost playbooks/clouds/build_$cloud_to_use.yml --connection=local
+ansible-playbook -i inventory/localhost "playbooks/clouds/build_${cloud_to_use}.yml" --connection=local
+

--- a/configure_ambari.sh
+++ b/configure_ambari.sh
@@ -1,36 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-if [ -z "$CLOUD_TO_USE" ]; then
-    echo "CLOUD_TO_USE environment variable must be set to one of the following: aws, azure, gce, openstack, static"
-    exit 1
-fi
+source "${BASH_SOURCE%/*}/set_cloud.sh"
 
-cloud_to_use=$(echo "$CLOUD_TO_USE" | tr '[:upper:]' '[:lower:]')
-case $cloud_to_use in
-aws|amazon)
-  cloud_to_use=aws
-  message="Cloud to be used is AWS.\nMake sure you've set the AWS authentication variables."
-  ;;
-azure|microsoft)
-  cloud_to_use=azure
-  message="Cloud to be used is Microsoft Azure.\nMake sure $HOME/.azure/credentials exists and it's correct."
-  ;;
-gce|google|gcp)
-  cloud_to_use=gce
-  message="Cloud to be used is Google Compute Engine.\nMake sure you've set the GCE authentication variables and JSON credentials file."
-  ;;
-openstack)
-  message="Cloud to be used is OpenStack.\nMake sure you've sourced the OpenStack RC file."
-  ;;
-static)
-  message="The static inventory will be used."
-  ;;
-*)
-  message="CLOUD_TO_USE environment variable was set to \"$CLOUD_TO_USE\" but must be set to one of the following: aws, azure, gce, openstack, static"
-  echo -e $message
-  exit 1
-  ;;
-esac
-
-echo -e $message
-ansible-playbook -i inventory/$cloud_to_use -e "cloud_name=$cloud_to_use" playbooks/configure_ambari.yml
+ansible-playbook -i "inventory/${cloud_to_use}" -e "cloud_name=${cloud_to_use}" playbooks/configure_ambari.yml

--- a/install_ambari.sh
+++ b/install_ambari.sh
@@ -1,36 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-if [ -z "$CLOUD_TO_USE" ]; then
-    echo "CLOUD_TO_USE environment variable must be set to one of the following: aws, azure, gce, openstack, static"
-    exit 1
-fi
+source "${BASH_SOURCE%/*}/set_cloud.sh"
 
-cloud_to_use=$(echo "$CLOUD_TO_USE" | tr '[:upper:]' '[:lower:]')
-case $cloud_to_use in
-aws|amazon)
-  cloud_to_use=aws
-  message="Cloud to be used is AWS.\nMake sure you've set the AWS authentication variables."
-  ;;
-azure|microsoft)
-  cloud_to_use=azure
-  message="Cloud to be used is Microsoft Azure.\nMake sure $HOME/.azure/credentials exists and it's correct."
-  ;;
-gce|google|gcp)
-  cloud_to_use=gce
-  message="Cloud to be used is Google Compute Engine.\nMake sure you've set the GCE authentication variables and JSON credentials file."
-  ;;
-openstack)
-  message="Cloud to be used is OpenStack.\nMake sure you've sourced the OpenStack RC file."
-  ;;
-static)
-  message="The static inventory will be used."
-  ;;
-*)
-  message="CLOUD_TO_USE environment variable was set to \"$CLOUD_TO_USE\" but must be set to one of the following: aws, azure, gce, openstack, static"
-  echo -e $message
-  exit 1
-  ;;
-esac
-
-echo -e $message
-ansible-playbook -i inventory/$cloud_to_use -e "cloud_name=$cloud_to_use" playbooks/install_ambari.yml
+ansible-playbook -i "inventory/${cloud_to_use}" -e "cloud_name=${cloud_to_use}" playbooks/install_ambari.yml

--- a/install_cluster.sh
+++ b/install_cluster.sh
@@ -1,36 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-if [ -z "$CLOUD_TO_USE" ]; then
-    echo "CLOUD_TO_USE environment variable must be set to one of the following: aws, azure, gce, openstack, static"
-    exit 1
-fi
+source "${BASH_SOURCE%/*}/set_cloud.sh"
 
-cloud_to_use=$(echo "$CLOUD_TO_USE" | tr '[:upper:]' '[:lower:]')
-case $cloud_to_use in
-aws|amazon)
-  cloud_to_use=aws
-  message="Cloud to be used is AWS.\nMake sure you've set the AWS authentication variables."
-  ;;
-azure|microsoft)
-  cloud_to_use=azure
-  message="Cloud to be used is Microsoft Azure.\nMake sure $HOME/.azure/credentials exists and it's correct."
-  ;;
-gce|google|gcp)
-  cloud_to_use=gce
-  message="Cloud to be used is Google Compute Engine.\nMake sure you've set the GCE authentication variables and JSON credentials file."
-  ;;
-openstack)
-  message="Cloud to be used is OpenStack.\nMake sure you've sourced the OpenStack RC file."
-  ;;
-static)
-  message="The static inventory will be used."
-  ;;
-*)
-  message="CLOUD_TO_USE environment variable was set to \"$CLOUD_TO_USE\" but must be set to one of the following: aws, azure, gce, openstack, static"
-  echo -e $message
-  exit 1
-  ;;
-esac
-
-echo -e $message
-ansible-playbook -i inventory/$cloud_to_use -e "cloud_name=$cloud_to_use" playbooks/install_cluster.yml
+ansible-playbook -i "inventory/${cloud_to_use}" -e "cloud_name=${cloud_to_use}" playbooks/install_cluster.yml

--- a/prepare_nodes.sh
+++ b/prepare_nodes.sh
@@ -1,36 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-if [ -z "$CLOUD_TO_USE" ]; then
-    echo "CLOUD_TO_USE environment variable must be set to one of the following: aws, azure, gce, openstack, static"
-    exit 1
-fi
+source "${BASH_SOURCE%/*}/set_cloud.sh"
 
-cloud_to_use=$(echo "$CLOUD_TO_USE" | tr '[:upper:]' '[:lower:]')
-case $cloud_to_use in
-aws|amazon)
-  cloud_to_use=aws
-  message="Cloud to be used is AWS.\nMake sure you've set the AWS authentication variables."
-  ;;
-azure|microsoft)
-  cloud_to_use=azure
-  message="Cloud to be used is Microsoft Azure.\nMake sure $HOME/.azure/credentials exists and it's correct."
-  ;;
-gce|google|gcp)
-  cloud_to_use=gce
-  message="Cloud to be used is Google Compute Engine.\nMake sure you've set the GCE authentication variables and JSON credentials file."
-  ;;
-openstack)
-  message="Cloud to be used is OpenStack.\nMake sure you've sourced the OpenStack RC file."
-  ;;
-static)
-  message="The static inventory will be used."
-  ;;
-*)
-  message="CLOUD_TO_USE environment variable was set to \"$CLOUD_TO_USE\" but must be set to one of the following: aws, azure, gce, openstack, static"
-  echo -e $message
-  exit 1
-  ;;
-esac
-
-echo -e $message
-ansible-playbook -i inventory/$cloud_to_use -e "cloud_name=$cloud_to_use" playbooks/prepare_nodes.yml
+ansible-playbook -i "inventory/${cloud_to_use}" -e "cloud_name=${cloud_to_use}" playbooks/prepare_nodes.yml

--- a/set_cloud.sh
+++ b/set_cloud.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+if [ -z "$CLOUD_TO_USE" ]; then
+    echo "CLOUD_TO_USE environment variable must be set to one of the following: aws, azure, gce, openstack, static"
+    exit 1
+fi
+
+cloud_to_use=$(echo "$CLOUD_TO_USE" | tr '[:upper:]' '[:lower:]')
+case $cloud_to_use in
+aws|amazon)
+  cloud_to_use=aws
+  message="Cloud to be used is AWS.\nMake sure you've set the AWS authentication variables."
+  ;;
+azure|microsoft)
+  cloud_to_use=azure
+  message="Cloud to be used is Microsoft Azure.\nMake sure $HOME/.azure/credentials exists and it's correct."
+  ;;
+gce|google|gcp)
+  cloud_to_use=gce
+  message="Cloud to be used is Google Compute Engine.\nMake sure you've set the GCE authentication variables and JSON credentials file."
+  ;;
+openstack)
+  message="Cloud to be used is OpenStack.\nMake sure you've sourced the OpenStack RC file."
+  ;;
+static)
+  message="The static inventory will be used."
+  ;;
+terraform)
+  message="The terraform inventory will be used."
+  ;;
+*)
+  message="CLOUD_TO_USE environment variable was set to \"$CLOUD_TO_USE\" but must be set to one of the following: aws, azure, gce, openstack, static, terraform"
+  echo -e $message
+  exit 1
+  ;;
+esac
+
+echo -e "${message}"
+


### PR DESCRIPTION
- By sourcing the CLOUD_TO_USE check from a single file (set_cloud.sh)