### PR TITLE
PostgreSQL and MySQL: get only enabled interfaces IP-addresses

### DIFF
--- a/playbooks/roles/database/tasks/mysql_play_db_access.yml
+++ b/playbooks/roles/database/tasks/mysql_play_db_access.yml
@@ -11,4 +11,4 @@
   loop_control:
     loop_var: local_loop
   with_items: "{{ hostvars[outer_loop]['ansible_interfaces'] }}"
-  when: local_loop != 'lo'
+  when: local_loop != 'lo' and 'ipv4' in hostvars[outer_loop]['ansible_'~local_loop]

--- a/playbooks/roles/database/tasks/postgres_play_db_access.yml
+++ b/playbooks/roles/database/tasks/postgres_play_db_access.yml
@@ -12,4 +12,4 @@
     loop_var: local_loop
   notify: Restart postgres
   with_items: "{{ hostvars[outer_loop]['ansible_interfaces'] }}"
-  when: local_loop != 'lo'
+  when: local_loop != 'lo' and 'ipv4' in hostvars[outer_loop]['ansible_'~local_loop]


### PR DESCRIPTION
Get addresses only from ipv4-enabled interfaces when allowing access.