### PR TITLE
WIP: build_aws should not have to load group_vars or other vars using 'vars_files'

### DIFF
--- a/playbooks/clouds/build_aws.yml
+++ b/playbooks/clouds/build_aws.yml
@@ -3,9 +3,10 @@
   hosts: localhost
   connection: local
   gather_facts: False
-  vars_files:
-    - ../group_vars/all
-    - ../../inventory/aws/group_vars/all
+  # loading following vars_files fails (and breaks the deployment) when calling the playbook from outside this repo
+#  vars_files:
+#    - ../group_vars/all
+#    - ../../inventory/aws/group_vars/all  
   tasks:
     - name: Create the VPC
       ec2_vpc_net:


### PR DESCRIPTION
* PR is WIP !
* Motivation in short: make those playbooks work when called from an another/external repository/folder (which allows to keep any customer specific configs in a separate and private repo)

Hi @alexandruanghel 
In our fork we have this change, which is obviously breaking the `build_cloud.sh` step for AWS, as it's currently done in the official repo.
Before trying to solve this properly and in a way acceptable to get it merged, I wanted to ask your opinion.
Tomorrow I will provide more details, and probably I should have started to create an issue first with the motivation  explained in more detail