### PR TITLE
add Name and optional Owner tags to the created AWS instances

### DIFF
--- a/playbooks/clouds/build_aws_nodes.yml
+++ b/playbooks/clouds/build_aws_nodes.yml
@@ -58,6 +58,8 @@
       Cluster: "{{ cluster_name }}"
       Role: "{{ outer_loop.host_group }}"
       Group: "{{ cluster_name }}-{{ outer_loop.host_group }}"
+      Name: "{{ cluster_name }}-{{ outer_loop.host_group }}"
+      Owner: "{{ cluster_owner | default('omit') }}"
     wait: yes
     wait_timeout: 600
   register: current_ec2


### PR DESCRIPTION
we have tested this!
* The automatically set 'Name' tag has been proven very useful in the AWS console  instances view 👍 
* The Owner tag is only set if one configures this (optional) variable, p.eg. in group_vars :
```
# Set the Owner(tag) to the deployer's username:
cluster_owner: "{{ lookup('env', 'USER') }}"
```