### PR TITLE
add some playbook tags  …

### DIFF
--- a/playbooks/clouds/build_aws.yml
+++ b/playbooks/clouds/build_aws.yml
@@ -14,6 +14,7 @@
         name: "{{ cloud_config.vpc_name }}"
         state: present
       register: cluster_vpc
+      tags: always
 
     - name: Create the Subnet
       ec2_vpc_subnet:
@@ -56,6 +57,7 @@
         rules: "{{ item.rules }}"
       with_items: "{{ cloud_config.security_groups }}"
       register: cluster_security_groups
+      tags: security_groups
 
     - name: Upload the SSH Key
       ec2_key:

--- a/playbooks/install_cluster.yml
+++ b/playbooks/install_cluster.yml
@@ -1,10 +1,15 @@
 ---
 - import_playbook: "prepare_nodes.yml"
+  tags: prepare_nodes
 
 - import_playbook: "install_ambari.yml"
+  tags: ambari
 
 - import_playbook: "configure_ambari.yml"
+  tags: ambari,blueprint
 
 - import_playbook: "apply_blueprint.yml"
+  tags: blueprint
 
 - import_playbook: "post_install.yml"
+  tags: post_install

--- a/playbooks/prepare_nodes.yml
+++ b/playbooks/prepare_nodes.yml
@@ -1,5 +1,6 @@
 ---
 - import_playbook: "set_variables.yml"
+  tags: always
 
 - name: Apply the common role to the hadoop-cluster group
   hosts: hadoop-cluster
@@ -7,6 +8,7 @@
   become: yes
   roles:
     - common
+  tags: common
 
 - name: Apply the database role to the ambari-server group
   hosts: ambari-server
@@ -15,6 +17,7 @@
   roles:
     - role: database
       when: database != "embedded" and not database_options.external_hostname|default('')
+  tags: database
 
 - name: Apply the krb5-client role to the hadoop-cluster group
   hosts: hadoop-cluster
@@ -23,6 +26,7 @@
   roles:
     - role: krb5-client
       when: security == "mit-kdc"
+  tags: mit-kdc
 
 - name: Apply the mit-kdc role to the ambari-server group
   hosts: ambari-server
@@ -31,3 +35,4 @@
   roles:
     - role: mit-kdc
       when: security == "mit-kdc" and not security_options.external_hostname|default('')
+  tags: mit-kdc


### PR DESCRIPTION
…including a tag 'database' to run only the db installation (part of the prepare_nodes playbook)

* With tags you are more flexible to (re)run a subset of the installation
* Also having the tags, IMO it's enough to have shell scripts `build_cloud.sh`, `install_cluster.sh`, and spare the others, because you can run the parts running the  install_cluster.sh --tags ...

Example to run only the database installation part (and also the internal `set_variables`, without which nothing works):
```
./install_cluster.sh -t database ...

# or directly calling the playbook (what we do to support a more customized inventory structure):
ansible-playbook playbooks/prepare_nodes.yml -t database -i inventory...
```

