### PR TITLE
install postgresql 9.6 from the official postgres repo on redhat7 and…

### DIFF
--- a/playbooks/roles/database/tasks/main.yml
+++ b/playbooks/roles/database/tasks/main.yml
@@ -79,17 +79,32 @@
       when: ansible_os_family|lower == "suse"
   when: database == "mariadb" and database_options.add_repo
 
+- block:
+    - name: install the PostgreSQL repository (yum)
+      yum_repository:
+        name: "{{ postgres_repo_name }}"
+        description: "PostgreSQL"
+        baseurl: "{{ postgres_repo_url }}"
+        state: present
+        gpgcheck: yes
+        gpgkey: "{{ postgres_repo_key }}"
+      when: ansible_os_family|lower == "redhat"
+  when: database == "postgres" and (postgres_repo_url|default(''))!=''
+
 - name: Install {{ database }} database packages
   package:
     name: "{{ item }}"
     update_cache: yes
     state: present
+#    enablerepo: "{{ postgres_enablerepo | default(omit) }}"
   with_items: "{{ hostvars[inventory_hostname][database + '_packages'] | join(',') }}"
 
 - block:
     - name: Initiate postgres
       become: yes
-      shell: "{{ postgres_initdb_command }}"
+      #become_user: "postgres"
+      #Note: Setting the task attribute 'become_user' is pointless because 'ansible_become_user' is set when adding the hosts to the inventory
+      shell: "sudo -u postgres {{ postgres_initdb_command }}"
       args:
         creates: "{{ postgres_hba_file }}"
         warn: false

--- a/playbooks/roles/database/tasks/main.yml
+++ b/playbooks/roles/database/tasks/main.yml
@@ -101,9 +101,7 @@
 - block:
     - name: Initiate postgres
       become: yes
-      #become_user: "postgres"
-      #Note: Setting the task attribute 'become_user' is pointless because 'ansible_become_user' is set when adding the hosts to the inventory
-      shell: "sudo -u postgres {{ postgres_initdb_command }}"
+      shell: "{{ postgres_initdb_command }}"
       args:
         creates: "{{ postgres_hba_file }}"
         warn: false

--- a/playbooks/roles/database/tasks/main.yml
+++ b/playbooks/roles/database/tasks/main.yml
@@ -89,14 +89,13 @@
         gpgcheck: yes
         gpgkey: "{{ postgres_repo_key }}"
       when: ansible_os_family|lower == "redhat"
-  when: database == "postgres" and (postgres_repo_url|default(''))!=''
+  when: database == "postgres" and database_options.add_repo and (postgres_repo_url|default(''))!=''
 
 - name: Install {{ database }} database packages
   package:
     name: "{{ item }}"
     update_cache: yes
     state: present
-#    enablerepo: "{{ postgres_enablerepo | default(omit) }}"
   with_items: "{{ hostvars[inventory_hostname][database + '_packages'] | join(',') }}"
 
 - block:

--- a/playbooks/roles/database/vars/redhat-7.yml
+++ b/playbooks/roles/database/vars/redhat-7.yml
@@ -1,10 +1,15 @@
 ---
+postgres_version: '9.6'
+postgres_repo_name: "pgdg{{ postgres_version | replace('.','') }}"
+postgres_repo_url: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-$releasever-$basearch"
+postgres_repo_key: "https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-{{ postgres_version | replace('.','') }}"
 postgres_packages:
-  - postgresql-server
-postgres_service_name: postgresql
-postgres_initdb_command: postgresql-setup initdb
-postgres_config_file: /var/lib/pgsql/data/postgresql.conf
-postgres_hba_file: /var/lib/pgsql/data/pg_hba.conf
+  - postgresql{{ postgres_version | replace('.','') }}-server
+postgres_service_name: postgresql-{{ postgres_version }}
+postgres_initdb_command: '/usr/pgsql-{{ postgres_version }}/bin/initdb -D {{ postgres_data_directory }}'
+postgres_data_directory: '/var/lib/pgsql/{{ postgres_version }}/data'
+postgres_config_file: '{{ postgres_data_directory }}/postgresql.conf'
+postgres_hba_file: '{{ postgres_data_directory }}/pg_hba.conf'
 
 mysql_version: '5.6'
 mysql_repo_url: 'http://repo.mysql.com/yum/mysql-{{ mysql_version }}-community/el/7/$basearch/'

--- a/playbooks/roles/database/vars/redhat-7.yml
+++ b/playbooks/roles/database/vars/redhat-7.yml
@@ -6,7 +6,7 @@ postgres_repo_key: "https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PG
 postgres_packages:
   - postgresql{{ postgres_version | replace('.','') }}-server
 postgres_service_name: postgresql-{{ postgres_version }}
-postgres_initdb_command: '/usr/pgsql-{{ postgres_version }}/bin/initdb -D {{ postgres_data_directory }}'
+postgres_initdb_command: '/usr/pgsql-{{ postgres_version }}/bin/postgresql96-setup initdb'
 postgres_data_directory: '/var/lib/pgsql/{{ postgres_version }}/data'
 postgres_config_file: '{{ postgres_data_directory }}/postgresql.conf'
 postgres_hba_file: '{{ postgres_data_directory }}/pg_hba.conf'

--- a/playbooks/roles/database/vars/redhat-amazon.yml
+++ b/playbooks/roles/database/vars/redhat-amazon.yml
@@ -1,10 +1,15 @@
 ---
+postgres_version: '9.6'
+postgres_repo_name: "pgdg{{ postgres_version | replace('.','') }}"
+postgres_repo_url: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-$releasever-$basearch"
+postgres_repo_key: "https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-{{ postgres_version | replace('.','') }}"
 postgres_packages:
-  - postgresql-server
-postgres_service_name: postgresql
-postgres_initdb_command: service postgresql initdb
-postgres_config_file: /var/lib/pgsql9/data/postgresql.conf
-postgres_hba_file: /var/lib/pgsql9/data/pg_hba.conf
+  - postgresql{{ postgres_version | replace('.','') }}-server
+postgres_service_name: postgresql-{{ postgres_version }}
+postgres_initdb_command: '/usr/pgsql-{{ postgres_version }}/bin/initdb -D {{ postgres_data_directory }}'
+postgres_data_directory: '/var/lib/pgsql/{{ postgres_version }}/data'
+postgres_config_file: '{{ postgres_data_directory }}/postgresql.conf'
+postgres_hba_file: '{{ postgres_data_directory }}/pg_hba.conf'
 
 mysql_version: '5.6'
 mysql_repo_url: 'http://repo.mysql.com/yum/mysql-{{ mysql_version }}-community/el/6/$basearch/'

--- a/playbooks/roles/database/vars/redhat-amazon.yml
+++ b/playbooks/roles/database/vars/redhat-amazon.yml
@@ -1,15 +1,10 @@
 ---
-postgres_version: '9.6'
-postgres_repo_name: "pgdg{{ postgres_version | replace('.','') }}"
-postgres_repo_url: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-$releasever-$basearch"
-postgres_repo_key: "https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-{{ postgres_version | replace('.','') }}"
 postgres_packages:
-  - postgresql{{ postgres_version | replace('.','') }}-server
-postgres_service_name: postgresql-{{ postgres_version }}
-postgres_initdb_command: '/usr/pgsql-{{ postgres_version }}/bin/initdb -D {{ postgres_data_directory }}'
-postgres_data_directory: '/var/lib/pgsql/{{ postgres_version }}/data'
-postgres_config_file: '{{ postgres_data_directory }}/postgresql.conf'
-postgres_hba_file: '{{ postgres_data_directory }}/pg_hba.conf'
+  - postgresql-server
+postgres_service_name: postgresql
+postgres_initdb_command: service postgresql initdb
+postgres_config_file: /var/lib/pgsql9/data/postgresql.conf
+postgres_hba_file: /var/lib/pgsql9/data/pg_hba.conf
 
 mysql_version: '5.6'
 mysql_repo_url: 'http://repo.mysql.com/yum/mysql-{{ mysql_version }}-community/el/6/$basearch/'


### PR DESCRIPTION
… redhat-amazon (to fix SchemaRegistry on HDP-3)

fix for https://github.com/hortonworks/ansible-hortonworks/issues/61

Notes: 
* I made it generic enough (using postgres_version variable similar to existing mysql_version), so it's also much easier to update for ex to postgres 10.2.x
* The current PR handles both redhat/centos-7 and redhat-Amazon (and using the exact same config variables)
  * tests were done (only ensured Ambari works) on HDP-2.6.5 (as HDP-3.0.x full stack test with postgres v9.6, done already)
  * probably these generic variables should also work for  redhat/centos-6 (but not tested) 
* following cmd, I had used in my first centos7 try, did not work anymore on Amazon linux, so I replaced by using directly the more standard 'initdb' cmd (used by most postgres roles):
>  postgres_initdb_command: postgresql96-setup initdb
* The test I did on Amazon (with working postgres 9.6 install), was using a recent Amazon-linux-2
(us-west-2    | amzn2-ami-hvm-2.0.20180810-x86_64-ebs | ami-99dafbe1), but starting up Ambari (HDP 2.6.5) failed with:
>  File "/usr/lib/ambari-agent/lib/ambari_commons/os_check.py", line 311, in _get_os_version   raise Exception("Cannot detect os version. Exiting...")
