### PR TITLE
allow user to define hadoop-cluster as part of larger inventory

### DIFF
--- a/playbooks/clouds/add_nodes_static.yml
+++ b/playbooks/clouds/add_nodes_static.yml
@@ -11,3 +11,5 @@
   loop_control:
     loop_var: local_loop
   with_items: "{{ groups['all'] }}"
+  when: groups['hadoop-cluster'] is not defined or groups['hadoop-cluster']|length == 0
+


### PR DESCRIPTION
Adding when statement to check if the hadoop-cluster variable is defined inside of a larger inventory file.  This allows for the use of an inventory file that is not specific to the ansible-hortonworks project

```
  when: groups['hadoop-cluster'] is not defined or groups['hadoop-cluster']|length == 0

```