### PR TITLE
load role default variables naturally, without include_vars task …

### DIFF
--- a/playbooks/roles/ambari-blueprint/tasks/main.yml
+++ b/playbooks/roles/ambari-blueprint/tasks/main.yml
@@ -1,7 +1,4 @@
 ---
-- name: Load default variables
-  include_vars:
-    file: 'defaults/main.yml'
 
 - name: Load variables
   include_vars: "{{ item }}"


### PR DESCRIPTION
…(which breaks group_var overrides)

Notes:
* tested the change
* apart a general cleanup, this is required for https://github.com/hortonworks/ansible-hortonworks/pull/75