### PR TITLE
Configurable local directories of all components and more

### DIFF
--- a/playbooks/roles/ambari-blueprint/defaults/main.yml
+++ b/playbooks/roles/ambari-blueprint/defaults/main.yml
@@ -6,3 +6,30 @@ mysql_port: 3306
 ## dynamic blueprint variables ##
 #################################
 registry_dns_bind_port: '53'
+
+## ZK  zoo.cfg:
+zookeeper_dataDir: "/hadoop/zookeeper"
+
+## HDFS
+dfs_namenode_checkpoint_dir: "/hadoop/hdfs/namesecondary"
+dfs_namenode_name_dir: "/hadoop/hdfs/namenode"
+dfs_datanode_data_dir: "/hadoop/hdfs/data"
+dfs_journalnode_edits_dir: "/hadoop/hdfs/journalnode"
+#nfs_file_dump_dir: "/tmp/.hdfs-nfs"
+hdfs_datanode_failed_volumes_tolerated: 0
+hdfs_replication: 3
+
+## Yarn
+yarn_nodemanager_local_dirs: "/hadoop/yarn/local"
+yarn_nodemanager_log_dirs: "/hadoop/yarn/log"
+yarn_timeline_service_leveldb_state_store_path: "/hadoop/yarn/timeline"
+yarn_timeline_service_leveldb_timeline_store_path: "/hadoop/yarn/timeline"
+
+## HBase
+hbase_rootdir: "/apps/hbase/data"
+hbase_bulkload_staging_dir: "/apps/hbase/staging"
+hbase_local_dir: "${hbase.tmp.dir}/local"
+#hbase_tmp_dir: "/tmp/hbase-${user.name}"
+
+# Oozie
+oozie_data_dir: "/hadoop/oozie/data"

--- a/playbooks/roles/ambari-blueprint/defaults/main.yml
+++ b/playbooks/roles/ambari-blueprint/defaults/main.yml
@@ -19,6 +19,11 @@ dfs_journalnode_edits_dir: "/hadoop/hdfs/journalnode"
 hdfs_datanode_failed_volumes_tolerated: 0
 hdfs_replication: 3
 
+hdfs_dtnode_heapsize: "1024m"
+hdfs_namenode_heapsize: "2048m"
+hdfs_namenode_opt_maxnewsize: "384m"
+hdfs_namenode_opt_newsize : "384m"
+
 ## Yarn
 yarn_nodemanager_local_dirs: "/hadoop/yarn/local"
 yarn_nodemanager_log_dirs: "/hadoop/yarn/log"

--- a/playbooks/roles/ambari-blueprint/defaults/main.yml
+++ b/playbooks/roles/ambari-blueprint/defaults/main.yml
@@ -40,3 +40,24 @@ kafka_offsets_topic_replication_factor: 3
 
 # Oozie
 oozie_data_dir: "/hadoop/oozie/data"
+
+## NIFI
+nifi_initial_mem: "512m"
+nifi_max_mem: "512m"
+nifi_content_repository_dir_default: "/var/lib/nifi/content_repository"
+nifi_database_dir: "/var/lib/nifi/database_repository"
+nifi_flowfile_repository_dir: "/var/lib/nifi/flowfile_repository"
+nifi_provenance_repository_dir_default: "/var/lib/nifi/provenance_repository"
+nifi_internal_dir: "/var/lib/nifi"
+nifi_state_dir: "{nifi_internal_dir}/state/local"
+nifi_flow_config_dir: "{nifi_internal_dir}/conf"
+#nifi_config_dir: "{nifi_install_dir}/conf"
+#Note: left out (in 1.try) because it uses ansible/jinja2 templating
+#nifi_database_directory: "{{nifi_database_dir}}"
+
+## NIFI-Registry
+nifi_registry_initial_mem: "512m"
+nifi_registry_max_mem: "512m"
+nifi_registry_internal_dir: "/var/lib/nifi-registry"
+nifi_registry_database_dir: "{nifi_registry_internal_dir}/database"
+nifi_registry_internal_config_dir: "{nifi_registry_internal_dir}/conf"

--- a/playbooks/roles/ambari-blueprint/defaults/main.yml
+++ b/playbooks/roles/ambari-blueprint/defaults/main.yml
@@ -31,5 +31,13 @@ hbase_bulkload_staging_dir: "/apps/hbase/staging"
 hbase_local_dir: "${hbase.tmp.dir}/local"
 #hbase_tmp_dir: "/tmp/hbase-${user.name}"
 
+## Kafka
+kafka_default_replication_factor: 1
+kafka_log_dirs: "/kafka-logs"
+kafka_log_retention_bytes: "-1"
+kafka_log_retention_hours: "168"
+kafka_num_partitions: 1
+kafka_offsets_topic_replication_factor: 3
+
 # Oozie
 oozie_data_dir: "/hadoop/oozie/data"

--- a/playbooks/roles/ambari-blueprint/defaults/main.yml
+++ b/playbooks/roles/ambari-blueprint/defaults/main.yml
@@ -25,12 +25,6 @@ yarn_nodemanager_log_dirs: "/hadoop/yarn/log"
 yarn_timeline_service_leveldb_state_store_path: "/hadoop/yarn/timeline"
 yarn_timeline_service_leveldb_timeline_store_path: "/hadoop/yarn/timeline"
 
-## HBase
-hbase_rootdir: "/apps/hbase/data"
-hbase_bulkload_staging_dir: "/apps/hbase/staging"
-hbase_local_dir: "${hbase.tmp.dir}/local"
-#hbase_tmp_dir: "/tmp/hbase-${user.name}"
-
 ## Kafka
 kafka_default_replication_factor: 1
 kafka_log_dirs: "/kafka-logs"

--- a/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
+++ b/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
@@ -720,10 +720,6 @@
     },
     {
       "hbase-site" : {
-        "hbase.rootdir" : "{{ hbase_rootdir }}",
-        "hbase.bulkload.staging.dir" : "{{ hbase_bulkload_staging_dir }}",
-        "hbase.local.dir" : "{{ hbase_local_dir }}",
-        "hbase.tmp.dir" : "/tmp/hbase-${user.name}",
         {% if namenode_groups|length > 1 -%}
         "hbase.rootdir": "hdfs://{{ hdfs_ha_name }}/apps/hbase/data",
         {% endif -%}

--- a/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
+++ b/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
@@ -362,15 +362,15 @@
       "nifi-ambari-config" : {
         "nifi.node.ssl.port": "9091",
         "nifi.node.port": "9090",
-        "nifi.initial_mem": "512m",
-        "nifi.max_mem": "512m",
-        "nifi.content.repository.dir.default": "/var/lib/nifi/content_repository",
-        "nifi.database.dir": "/var/lib/nifi/database_repository",
-        "nifi.flowfile.repository.dir": "/var/lib/nifi/flowfile_repository",
-        "nifi.provenance.repository.dir.default": "/var/lib/nifi/provenance_repository",
-        "nifi.internal.dir": "/var/lib/nifi",
-        "nifi.state.dir": "{nifi_internal_dir}/state/local",
-        "nifi.flow.config.dir": "{nifi_internal_dir}/conf",
+        "nifi.initial_mem": "{{ nifi_initial_mem }}",
+        "nifi.max_mem": "{{ nifi_max_mem }}",
+        "nifi.content.repository.dir.default": "{{ nifi_content_repository_dir_default }}",
+        "nifi.database.dir": "{{ nifi_database_dir }}",
+        "nifi.flowfile.repository.dir": "{{ nifi_flowfile_repository_dir }}",
+        "nifi.provenance.repository.dir.default": "{{ nifi_provenance_repository_dir_default }}",
+        "nifi.internal.dir": "{{ nifi_internal_dir }}",
+        "nifi.state.dir": "{{ nifi_state_dir }}",
+        "nifi.flow.config.dir": "{{ nifi_flow_config_dir }}",
         "nifi.security.encrypt.configuration.password": "{{ nifi_security_options.encrypt_password }}",
         "nifi.sensitive.props.key": "{{ nifi_security_options.sensitive_props_key }}"
       }
@@ -392,11 +392,11 @@
 {% if hdf_minor_version is version_compare('3.2', '>=') %}
         "nifi.registry.db.password": "{{ nifi_security_options.encrypt_password }}",
 {% endif %}
-        "nifi.registry.initial_mem": "512m",
-        "nifi.registry.max_mem": "512m",
-        "nifi.registry.database.dir": "{nifi_registry_internal_dir}/database",
-        "nifi.registry.internal.config.dir": "{nifi_registry_internal_dir}/conf",
-        "nifi.registry.internal.dir": "/var/lib/nifi-registry",
+        "nifi.registry.initial_mem": "{{ nifi_registry_initial_mem }}",
+        "nifi.registry.max_mem": "{{ nifi_registry_max_mem }}",
+        "nifi.registry.internal.dir": "{{ nifi_registry_internal_dir }}",
+        "nifi.registry.database.dir": "{{ nifi_registry_database_dir }}",
+        "nifi.registry.internal.config.dir": "{{ nifi_registry_internal_config_dir }}",
         "nifi.registry.web.jetty.threads" : "200"
       }
     },

--- a/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
+++ b/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
@@ -824,12 +824,12 @@
 {% if rangeradmin_hosts|length > 0 and ranger_options.enable_plugins|default(no) %}
         "authorizer.class.name" : "org.apache.ranger.authorization.kafka.authorizer.RangerKafkaAuthorizer",
 {% endif %}
-        "default.replication.factor": "1",
-        "log.dirs": "/kafka-logs",
-        "log.retention.hours": "168",
-        "log.retention.bytes": "-1",
-        "num.partitions": "1",
-        "offsets.topic.replication.factor": "3",
+        "default.replication.factor": "{{ kafka_default_replication_factor }}",
+        "log.dirs": "{{ kafka_log_dirs }}",
+        "log.retention.bytes": "{{ kafka_log_retention_bytes }}",
+        "log.retention.hours": "{{ kafka_log_retention_hours }}",
+        "num.partitions": "{{ kafka_num_partitions }}",
+        "offsets.topic.replication.factor": "{{ kafka_offsets_topic_replication_factor }}",
         "zookeeper.session.timeout.ms" : "30000"
       }
     },

--- a/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
+++ b/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
@@ -437,6 +437,9 @@
     },
     {
       "hdfs-site" : {
+        "dfs.namenode.checkpoint.dir" : "/hadoop/hdfs/namesecondary",
+        "dfs.namenode.name.dir" : "/hadoop/hdfs/namenode",
+        "dfs.journalnode.edits.dir" : "/hadoop/hdfs/journalnode",
         {% if namenode_groups|length > 1 -%}
         "dfs.client.failover.proxy.provider.{{ hdfs_ha_name }}" : "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider",
         "dfs.ha.automatic-failover.enabled" : "true",
@@ -457,9 +460,9 @@
 {% if rangerkms_hosts|length > 0 %}
         "dfs.encryption.key.provider.uri" : "kms://http@{% for kmshost in rangerkms_hosts %}{{ hostvars[kmshost]['ansible_fqdn'] }}{% if not loop.last %};{% endif %}{% endfor %}:9292/kms",
 {% endif %}
-        "dfs.datanode.data.dir" : "/hadoop/hdfs/data",
-        "dfs.datanode.failed.volumes.tolerated" : "0",
-        "dfs.replication" : "3"
+        "dfs.datanode.data.dir" : "{{ hdfs_datanode_data_dir }}",
+        "dfs.datanode.failed.volumes.tolerated" : "{{ hdfs_datanode_failed_volumes_tolerated }}",
+        "dfs.replication" : "{{ hdfs_replication }}"
       }
     },
     {
@@ -502,6 +505,10 @@
 {% if 'YARN_REGISTRY_DNS' in blueprint_all_services %}
         "hadoop.registry.dns.bind-port": "{{ registry_dns_bind_port | default('53') }}",
 {% endif %}
+        "yarn.nodemanager.local-dirs" : "/hadoop/yarn/local",
+        "yarn.nodemanager.log-dirs" : "/hadoop/yarn/log",
+        "yarn.timeline-service.leveldb-state-store.path" : "/hadoop/yarn/timeline",
+        "yarn.timeline-service.leveldb-timeline-store.path" : "/hadoop/yarn/timeline",
         "yarn.client.nodemanager-connect.retry-interval-ms" : "10000"
       }
     },
@@ -680,6 +687,7 @@
 {% if (security|lower == "mit-kdc" or security|lower == "active-directory") and security_options.http_authentication|default(no) %}
         "oozie.authentication.cookie.domain" : "{{ security_options.realm|lower }}",
 {% endif %}
+        "oozie_data_dir" : "/hadoop/oozie/data",
         "oozie.action.retry.interval" : "30"
       }
     },
@@ -698,6 +706,10 @@
     },
     {
       "hbase-site" : {
+        "hbase.rootdir" : "/apps/hbase/data",
+        "hbase.bulkload.staging.dir" : "/apps/hbase/staging",
+        "hbase.local.dir" : "${hbase.tmp.dir}/local",
+        "hbase.tmp.dir" : "/tmp/hbase-${user.name}",
         {% if namenode_groups|length > 1 -%}
         "hbase.rootdir": "hdfs://{{ hdfs_ha_name }}/apps/hbase/data",
         {% endif -%}
@@ -803,6 +815,7 @@
     },
     {
       "zoo.cfg": {
+        "dataDir" : "{{ zookeeper_dataDir }}",
         "clientPort" : "2181"
       }
     }

--- a/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
+++ b/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
@@ -443,10 +443,10 @@
 {% if namenode_groups|length > 0 %}
     {
       "hadoop-env" : {
-        "dtnode_heapsize" : "1024m",
-        "namenode_heapsize" : "2048m",
-        "namenode_opt_maxnewsize" : "384m",
-        "namenode_opt_newsize" : "384m"
+        "dtnode_heapsize" : "{{ hdfs_dtnode_heapsize }}",
+        "namenode_heapsize" : "{{ hdfs_namenode_heapsize }}",
+        "namenode_opt_maxnewsize" : "{{ hdfs_namenode_opt_maxnewsize }}",
+        "namenode_opt_newsize" : "{{ hdfs_namenode_opt_newsize }}"
       }
     },
     {

--- a/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
+++ b/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
@@ -362,6 +362,15 @@
       "nifi-ambari-config" : {
         "nifi.node.ssl.port": "9091",
         "nifi.node.port": "9090",
+        "nifi.initial_mem": "512m",
+        "nifi.max_mem": "512m",
+        "nifi.content.repository.dir.default": "/var/lib/nifi/content_repository",
+        "nifi.database.dir": "/var/lib/nifi/database_repository",
+        "nifi.flowfile.repository.dir": "/var/lib/nifi/flowfile_repository",
+        "nifi.provenance.repository.dir.default": "/var/lib/nifi/provenance_repository",
+        "nifi.internal.dir": "/var/lib/nifi",
+        "nifi.state.dir": "{nifi_internal_dir}/state/local",
+        "nifi.flow.config.dir": "{nifi_internal_dir}/conf",
         "nifi.security.encrypt.configuration.password": "{{ nifi_security_options.encrypt_password }}",
         "nifi.sensitive.props.key": "{{ nifi_security_options.sensitive_props_key }}"
       }
@@ -383,6 +392,11 @@
 {% if hdf_minor_version is version_compare('3.2', '>=') %}
         "nifi.registry.db.password": "{{ nifi_security_options.encrypt_password }}",
 {% endif %}
+        "nifi.registry.initial_mem": "512m",
+        "nifi.registry.max_mem": "512m",
+        "nifi.registry.database.dir": "{nifi_registry_internal_dir}/database",
+        "nifi.registry.internal.config.dir": "{nifi_registry_internal_dir}/conf",
+        "nifi.registry.internal.dir": "/var/lib/nifi-registry",
         "nifi.registry.web.jetty.threads" : "200"
       }
     },

--- a/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
+++ b/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
@@ -824,6 +824,12 @@
 {% if rangeradmin_hosts|length > 0 and ranger_options.enable_plugins|default(no) %}
         "authorizer.class.name" : "org.apache.ranger.authorization.kafka.authorizer.RangerKafkaAuthorizer",
 {% endif %}
+        "default.replication.factor": "1",
+        "log.dirs": "/kafka-logs",
+        "log.retention.hours": "168",
+        "log.retention.bytes": "-1",
+        "num.partitions": "1",
+        "offsets.topic.replication.factor": "3",
         "zookeeper.session.timeout.ms" : "30000"
       }
     },

--- a/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
+++ b/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
@@ -451,9 +451,9 @@
     },
     {
       "hdfs-site" : {
-        "dfs.namenode.checkpoint.dir" : "/hadoop/hdfs/namesecondary",
-        "dfs.namenode.name.dir" : "/hadoop/hdfs/namenode",
-        "dfs.journalnode.edits.dir" : "/hadoop/hdfs/journalnode",
+        "dfs.namenode.checkpoint.dir" : "{{ dfs_namenode_checkpoint_dir }}",
+        "dfs.namenode.name.dir" : "{{ dfs_namenode_name_dir }}",
+        "dfs.journalnode.edits.dir" : "{{ dfs_journalnode_edits_dir }}",
         {% if namenode_groups|length > 1 -%}
         "dfs.client.failover.proxy.provider.{{ hdfs_ha_name }}" : "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider",
         "dfs.ha.automatic-failover.enabled" : "true",
@@ -474,7 +474,7 @@
 {% if rangerkms_hosts|length > 0 %}
         "dfs.encryption.key.provider.uri" : "kms://http@{% for kmshost in rangerkms_hosts %}{{ hostvars[kmshost]['ansible_fqdn'] }}{% if not loop.last %};{% endif %}{% endfor %}:9292/kms",
 {% endif %}
-        "dfs.datanode.data.dir" : "{{ hdfs_datanode_data_dir }}",
+        "dfs.datanode.data.dir" : "{{ dfs_datanode_data_dir }}",
         "dfs.datanode.failed.volumes.tolerated" : "{{ hdfs_datanode_failed_volumes_tolerated }}",
         "dfs.replication" : "{{ hdfs_replication }}"
       }
@@ -519,10 +519,10 @@
 {% if 'YARN_REGISTRY_DNS' in blueprint_all_services %}
         "hadoop.registry.dns.bind-port": "{{ registry_dns_bind_port | default('53') }}",
 {% endif %}
-        "yarn.nodemanager.local-dirs" : "/hadoop/yarn/local",
-        "yarn.nodemanager.log-dirs" : "/hadoop/yarn/log",
-        "yarn.timeline-service.leveldb-state-store.path" : "/hadoop/yarn/timeline",
-        "yarn.timeline-service.leveldb-timeline-store.path" : "/hadoop/yarn/timeline",
+        "yarn.nodemanager.local-dirs" : "{{ yarn_nodemanager_local_dirs }}",
+        "yarn.nodemanager.log-dirs" : "{{ yarn_nodemanager_log_dirs }}",
+        "yarn.timeline-service.leveldb-state-store.path" : "{{ yarn_timeline_service_leveldb_state_store_path }}",
+        "yarn.timeline-service.leveldb-timeline-store.path" : "{{ yarn_timeline_service_leveldb_timeline_store_path }}",
         "yarn.client.nodemanager-connect.retry-interval-ms" : "10000"
       }
     },
@@ -701,7 +701,7 @@
 {% if (security|lower == "mit-kdc" or security|lower == "active-directory") and security_options.http_authentication|default(no) %}
         "oozie.authentication.cookie.domain" : "{{ security_options.realm|lower }}",
 {% endif %}
-        "oozie_data_dir" : "/hadoop/oozie/data",
+        "oozie_data_dir" : "{{ oozie_data_dir }}",
         "oozie.action.retry.interval" : "30"
       }
     },
@@ -720,9 +720,9 @@
     },
     {
       "hbase-site" : {
-        "hbase.rootdir" : "/apps/hbase/data",
-        "hbase.bulkload.staging.dir" : "/apps/hbase/staging",
-        "hbase.local.dir" : "${hbase.tmp.dir}/local",
+        "hbase.rootdir" : "{{ hbase_rootdir }}",
+        "hbase.bulkload.staging.dir" : "{{ hbase_bulkload_staging_dir }}",
+        "hbase.local.dir" : "{{ hbase_local_dir }}",
         "hbase.tmp.dir" : "/tmp/hbase-${user.name}",
         {% if namenode_groups|length > 1 -%}
         "hbase.rootdir": "hdfs://{{ hdfs_ha_name }}/apps/hbase/data",


### PR DESCRIPTION

Notes:
*  *Unfortunately* https://github.com/hortonworks/ansible-hortonworks/pull/72 I was not aware yet, when I started implementing this, as it has mostly the same intention, and changes (Had I checked here earlier, I'ld have build on it!)
** In my PR I decided from the start to introduce 1 variable per blueprint variable, which makes it 100% flexible to configure different (base)dirs for each component (that would be nice to be changed in #72, if it got accepted instead 👍 )
* The 1.commit is the same as in PR: https://github.com/hortonworks/ansible-hortonworks/pull/74
** (Once that fix PR is merged I can rebase this PR)
* each new variable is defined in the ambari-blueprint role defaults
* no extra tasks are required (so its easy to test)
** actually 1 task had to be removed (see 1.comment)
* commits can be stashed or cleaned up (I kept them for now, as they are somewhat atomic) 

List of params taken from an existing blueprint (from a cluster deployed using the role), where some lines are commented (which I did not yet make configurable for reasons):
```
## ZK
            "zoo.cfg": {
                    "dataDir": "/hadoop/zookeeper"

## HDFS
                    "dfs.namenode.checkpoint.dir": "/hadoop/hdfs/namesecondary",
                    "dfs.namenode.name.dir": "/hadoop/hdfs/namenode",
                    "dfs.datanode.data.dir": "/hadoop/hdfs/data",
                    "dfs.journalnode.edits.dir": "/hadoop/hdfs/journalnode",
#                    "nfs.file.dump.dir": "/tmp/.hdfs-nfs",
#                   "hadoop_heapsize": "1024",
                    "dtnode_heapsize": "1024m",
                    "namenode_heapsize": "2048m",
                    "namenode_opt_newsize": "384m",
                    "namenode_opt_maxnewsize": "384m",
#                   "namenode_opt_maxpermsize": "256m",
#                   "namenode_opt_permsize": "128m",

## Yarn
                    "yarn.nodemanager.local-dirs": "/hadoop/yarn/local"
                    "yarn.nodemanager.log-dirs": "/hadoop/yarn/log"
                    "yarn.timeline-service.leveldb-state-store.path": "/hadoop/yarn/timeline"
                    "yarn.timeline-service.leveldb-timeline-store.path": "/hadoop/yarn/timeline"

## HBase
                    "hbase.rootdir": "/apps/hbase/data"
                    "hbase.bulkload.staging.dir": "/apps/hbase/staging"
                    "hbase.local.dir": "${hbase.tmp.dir}/local"
#                    "hbase.tmp.dir": "/tmp/hbase-${user.name}"

## Kafka
                    "default.replication.factor": "1",
                    "log.dirs": "/kafka-logs",
                    "log.retention.hours": "168",
                    "log.retention.bytes": "-1",
                    "num.partitions": "1",
                    "offsets.topic.replication.factor": "3",

## Oozie
                    "oozie_data_dir": "/hadoop/oozie/data"
#                    "oozie_heapsize": "2048m",

## NIFI
                    "nifi.initial_mem": "512m"
                    "nifi.max_mem": "512m"
                    "nifi.content.repository.dir.default": "/var/lib/nifi/content_repository"
                    "nifi.database.dir": "/var/lib/nifi/database_repository"
# left out (in 1.try) because it uses ansible/jinja2 templating 
#                    "nifi.database.directory": "{{nifi_database_dir}}"
                    "nifi.flowfile.repository.dir": "/var/lib/nifi/flowfile_repository"
                    "nifi.provenance.repository.dir.default": "/var/lib/nifi/provenance_repository"
	             "nifi.internal.dir": "/var/lib/nifi"
                    "nifi.state.dir": "{nifi_internal_dir}/state/local"
                    "nifi.flow.config.dir": "{nifi_internal_dir}/conf"
#                    "nifi.config.dir": "{nifi_install_dir}/conf"

## NIFI-Registry
                    "nifi.registry.initial_mem": "512m"
                    "nifi.registry.max_mem": "512m"
                    "nifi.registry.database.dir": "{nifi_registry_internal_dir}/database"
                    "nifi.registry.internal.config.dir": "{nifi_registry_internal_dir}/conf"
                    "nifi.registry.internal.dir": "/var/lib/nifi-registry"
#                    "nifi.registry.config.dir": "{nifi_registry_install_dir}/conf"
```
