### PR TITLE
fix: properly omit AWS Owner tag when not defined

### DIFF
--- a/playbooks/clouds/build_aws_nodes.yml
+++ b/playbooks/clouds/build_aws_nodes.yml
@@ -59,7 +59,7 @@
       Role: "{{ outer_loop.host_group }}"
       Group: "{{ cluster_name }}-{{ outer_loop.host_group }}"
       Name: "{{ cluster_name }}-{{ outer_loop.host_group }}"
-      Owner: "{{ cluster_owner | default('omit') }}"
+      Owner: "{{ cluster_owner | default(omit) }}"
     wait: yes
     wait_timeout: 600
   register: current_ec2


### PR DESCRIPTION
small fix for  https://github.com/hortonworks/ansible-hortonworks/pull/63 feature:
properly omit the AWS (instances) Owner tag for the default case (`cluster_owner` not defined), instead of writing a 'strange' numeric tag value
