### PR TITLE
set ulimits based on smartsense recommendations

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -60,6 +60,19 @@
       * hard nofile 32768
       * soft nproc 32768
       * hard nproc 32768
+      root       soft    nproc     unlimited
+      ams        -       nofile   64000
+      atlas      -       nofile   64000
+      druid      -       nofile   64000
+      hive       -       nofile   64000
+      infra-solr -       nofile   64000
+      kms        -       nofile   64000
+      knox       -       nofile   64000
+      logsearch  -       nofile   64000
+      ranger     -       nofile   64000
+      spark      -       nofile   64000
+      zeppelin   -       nofile   64000
+      zookeeper  -       nofile   64000
     marker: "# {mark} ANSIBLE MANAGED BLOCK"
 
 - name: Set swappiness to {{ swappiness }}


### PR DESCRIPTION
SmartSense recommends `nofile` limits of 64000 for most services. This covers the services which are not managed by Ambari.

Alternatively we could raise the default limit to 64000.