### PR TITLE
configurable mpack base urls (new optional vars: hdf_mpack_base_url, solr_mpack_base_url)

### DIFF
--- a/playbooks/roles/ambari-config/tasks/main.yml
+++ b/playbooks/roles/ambari-config/tasks/main.yml
@@ -39,9 +39,10 @@
     - name: Set the HDP Search mpack filename
       set_fact:
         mpack_filename: "solr-service-mpack-{{ hdpsearch_version }}.tar.gz"
+        mpack_base_url: "{{ solr_mpack_base_url | default( repo_base_url+ '/HDP-SOLR/hdp-solr-ambari-mp') }}"
 
     - name: "Install the HDP Search Management Pack"
-      shell: "echo yes | ambari-server install-mpack --mpack={{ repo_base_url }}/HDP-SOLR/hdp-solr-ambari-mp/{{ mpack_filename }}"
+      shell: "echo yes | ambari-server install-mpack --mpack={{ mpack_base_url }}/{{ mpack_filename }}"
       notify: Restart ambari-server
       args:
         creates: "/var/lib/ambari-server/resources/mpacks/solr-ambari-mpack-{{ hdpsearch_version }}"
@@ -64,16 +65,17 @@
     - name: Set the HDF mpack filename
       set_fact:
         mpack_filename: "hdf-ambari-mpack-{{ hdf_version }}-{{ hdf_build_number_auto|default(hdf_build_number) }}.tar.gz"
+        mpack_base_url: "{{ hdf_mpack_base_url | default( hdf_main_repo_url+ '/tars/hdf_ambari_mp') }}"
 
     - name: "Install the HDF Management Pack"
-      shell: "echo yes | ambari-server install-mpack --mpack={{ hdf_main_repo_url }}/tars/hdf_ambari_mp/{{ mpack_filename }}"
+      shell: "echo yes | ambari-server install-mpack --mpack={{ mpack_base_url }}/{{ mpack_filename }}"
       notify: Restart ambari-server
       args:
         creates: "/var/lib/ambari-server/resources/mpacks/{{ mpack_filename | regex_replace('.tar.gz$','') }}"
       when: hdf_major_version|int >= 3
 
     - name: "Install the HDF Management Pack (with --purge)"
-      shell: "echo yes | ambari-server install-mpack --mpack={{ hdf_main_repo_url }}/tars/hdf_ambari_mp/{{ mpack_filename }} --purge"
+      shell: "echo yes | ambari-server install-mpack --mpack={{ mpack_base_url }}/{{ mpack_filename }} --purge"
       notify: Restart ambari-server
       args:
         creates: "/var/lib/ambari-server/resources/mpacks/{{ mpack_filename | regex_replace('.tar.gz$','') }}"


### PR DESCRIPTION
The most simple, least disruptive and downward compatible extension to 
fulfill (my) feature request ( https://github.com/hortonworks/ansible-hortonworks/issues/78 ) to be able to override the mpack's base url without the base url (also) used to define the yum repositories.

Example config, to get the mpacks from a local `/tmp` folder:
```
hdf_mpack_base_url: "file:///tmp"
solr_mpack_base_url: "file:///tmp"
```
wdyt @alexandruanghel (other contributors @zer0glitch , @laurentedel ?)

---
Impl. infos:
* That solution is very similar to (2) that I had proposed (in issue link)
  * (Update: Also similar to @zer0glitch 's same feature in their fork https://github.com/sscpac/ansible-hortonworks/commit/ccfee352dac8ae663ef65f11ad5053ea76705994#diff-10982c800087846025ff1911d601db91 )
* Initially I was thinking if/howto achieve it through a more configurable `hdf_main_repo_url` , but was quickly giving that up, because the fact that this var is defined via `include_vars` loading does not make it overrideable in group_vars. (As long as ansible does not support something like https://github.com/ansible/ansible/issues/14248#issuecomment-254059046 or https://github.com/ansible/proposals/pull/21 )
