### PR TITLE
allow to disable the ambari-repo role by setting new optional variable ambari_repo_enabled=false

### DIFF
--- a/playbooks/roles/ambari-agent/meta/main.yml
+++ b/playbooks/roles/ambari-agent/meta/main.yml
@@ -1,3 +1,5 @@
 ---
 dependencies:
-  - { role: ambari-repo }
+  - role: ambari-repo
+    when: ambari_repo_enabled | default(True) | bool
+    

--- a/playbooks/roles/ambari-server/meta/main.yml
+++ b/playbooks/roles/ambari-server/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
-  - { role: ambari-repo }
+  - role: ambari-repo
+    when: ambari_repo_enabled | default(True) | bool


### PR DESCRIPTION
UPDATED (initial pushed version did not work, details at the end)

Notes:
* Change is fully downward compatible (as `ambari_repo_enabled` does not need to be defined)
* (tested) deployment by overriding the `ambari_repo_enabled` on the cmdline (p.eg the agent playbook):
```
./install_cluster.sh -v  -t ambari-agent -e ambari_repo_enabled=false  <-i inventory... etc>
```

Details, why initial solution was broken:
Of course we cannot use a check on the `ambari_repo_url` , in the dependency loading phase, as the var gets loaded only in the tasks!
I will submit a fix ASAP using  the new var proposal with ``
