### PR TITLE
Support Satellite/Spacewalk repositories by setting new (optional) flag…

### DIFF
--- a/playbooks/roles/ambari-config/tasks/main.yml
+++ b/playbooks/roles/ambari-config/tasks/main.yml
@@ -208,6 +208,28 @@
       when: (existing_vdf.content|from_yaml)['items'] | length == 0
   when: ambari_version is version_compare('2.6', '>=')
 
+- block:
+    - name: Generate repo_version API request body from template
+      template:
+        src: "{{ repo_version_template | default('repo_version_template.json.j2') }}"
+        dest: /tmp/repo_version_update_body.json
+      become: False  
+      delegate_to: localhost        
+
+    - name: Update repo_version model to set ambari_managed_repositories=false
+      uri:
+        url: "http://{{ ansible_fqdn }}:8080/api/v1/stacks/HDP/versions/{{ hdp_minor_version }}/repository_versions/1"
+        method: PUT
+        force_basic_auth: yes
+        user: "{{ ambari_admin_user }}"
+        password: "{{ ambari_admin_password }}"
+        headers:
+          "X-Requested-By": "ambari"
+          "Content-type": "Application/json"
+        body: "{{ lookup('file', '/tmp/repo_version_update_body.json')|to_json }}"
+        status_code: 200
+  when: not (ambari_managed_repositories|default(True))
+
 - meta: flush_handlers
 
 - name: Make sure all of the Ambari Agents have registered

--- a/playbooks/roles/ambari-config/templates/repo_version_template.json.j2
+++ b/playbooks/roles/ambari-config/templates/repo_version_template.json.j2
@@ -1,0 +1,51 @@
+{  
+  "operating_systems":[  
+    {  
+      "OperatingSystems":{  
+        "ambari_managed_repositories":false, 
+        "os_type":"{{ baseurl_os_family }}"
+      }, 
+      "repositories":[  
+        {  
+          "Repositories":{  
+            "base_url":"{{ hdp_main_repo_url }}", 
+            "repo_id":"HDP-{{ hdp_minor_version }}",
+            "repo_name":"HDP" 
+          } 
+        }, 
+{% if install_hdf|default(false) %}
+        {  
+          "Repositories":{  
+            "base_url":"{{ hdf_main_repo_url }}", 
+            "repo_id":"HDF-{{ hdf_minor_version }}", 
+            "repo_name":"HDF" 
+          } 
+        }, 
+{% endif %}
+{% if install_hdpsearch|default(false) and hdpsearch_main_repo_url is defined %}
+        {  
+          "Repositories":{  
+            "base_url":"{{ hdpsearch_main_repo_url }}", 
+            "repo_id":"HDP-SOLR-{{ hdpsearch_version }}-{{ hdpsearch_build_number }}", 
+            "repo_name":"HDP-SOLR" 
+          } 
+        }, 
+{% endif %}  
+        {  
+          "Repositories":{  
+            "base_url":"{{ utils_repo_url }}", 
+            "repo_id":"HDP-UTILS-{{ utils_version }}", 
+            "repo_name":"HDP-UTILS" 
+          } 
+        }, 
+        {  
+          "Repositories":{  
+            "base_url":"{{ gpl_repo_url }}", 
+            "repo_id":"HDP-{{ hdp_minor_version }}-GPL",
+            "repo_name":"HDP-GPL" 
+          } 
+        } 
+      ]
+    }
+  ] 
+}


### PR DESCRIPTION
…ag ambari_managed_repositories=false

This implements https://github.com/hortonworks/ansible-hortonworks/issues/112

Inspired from @zer0glitch 's fork implementation (thanks !)
* as explained here: https://github.com/hortonworks/ansible-hortonworks/pull/133#issuecomment-469354762
* and here https://github.com/hortonworks/ansible-hortonworks/issues/112#issuecomment-447199440
* with slight differences
  * I added the required repository_versions API PUT (update) request in the `ambari-config` role, directly after the VDF registration (which seems more natural, also in the role we have some related vars ready for re-use)
  * I kept it completely generic AND ensure that the 'updated' repositories stay the same (same id,name,url).
  * ps: I also tried the API request without the `repositories` element (with the idea to only touch the `OperatingSystems` to change the `ambari_managed_repositories` flag), but that resulted in failing request.

Tests done:
* a complete deployment, with setting `ambari_managed_repositories=false` (enables new logic)
  * verified that the flag change applied doing a GET request (`http://{{ansible_fqdn}}:8080/api/v1/stacks/HDP/versions/{{hdp_minor_version}}/repository_versions/1/operating_systems/redhat7` )
  * verified that Ambari did in fact *not manage/add* the repositories (and I completed the install by manually adding the yum *repo files on the nodes, just to test)
  * verified in the Ambari UI  the `use Satellite/Spacewalk` flag checked!
* a complete deployment, with setting `ambari_managed_repositories=false` and changing ambari_managed_repositories=true in the new template  (`repo_version_update_body.json.j2`)
  * verified again with the GET request (on repository_versions/1)
  * verified (by diffing) that the updated repositories where in fact the same as before doing the request  (so the new logic could also be used to set the repositories for all cases, and remove the logic from the VDF!?)
  * verified that Ambari *managed* the repositories (and so the install worked normally, as without the new feature)
* TODO Test with real Satellite or Spacewalk (coming soon, at the customer install), though I'm confident this will work 
