### PR TITLE
[Patch] Bug select hdp/hdf

### DIFF
--- a/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
+++ b/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
@@ -856,7 +856,7 @@
       "type" : "KERBEROS"
     },
 {% endif %}
-    "stack_name" : "{% if namenode_groups|length > 0 %}HDP{% else %}HDF{% endif %}",
-    "stack_version" : "{% if namenode_groups|length > 0 %}{{ hdp_minor_version }}{% else %}{{ hdf_minor_version }}{% endif %}"
+    "stack_name" : "{% if install_hdp|default(false) %}HDP{% else %}HDF{% endif %}",
+    "stack_version" : "{% if install_hdp|default(false) %}{{ hdp_minor_version }}{% else %}{{ hdf_minor_version }}{% endif %}"
   }
 }


### PR DESCRIPTION
When deploying simple cluster (like only kafka / zookeeper) the playbooks doesn't detect `install_hdp` nor `install_hdf`.  
All tests defaulting to hdf, but we can pass `--extra-vars "install_hdp=true"` to force using hdp.  
Here we reuse that variable defined in `set_variables.yml` to allow this feature