### PR TITLE
add database access rule for the spark2_historyserver to the hiveserver

### DIFF
--- a/playbooks/set_variables.yml
+++ b/playbooks/set_variables.yml
@@ -163,7 +163,7 @@
         - name: Populate the hiveserver hosts list
           set_fact:
             hiveserver_hosts: "{{ hiveserver_hosts }} + {{ groups[item.host_group] }}"
-          when: groups[item.host_group] is defined and groups[item.host_group]|length > 0 and ('HIVE_SERVER' in item.services or 'HIVE_METASTORE' in item.services)
+          when: groups[item.host_group] is defined and groups[item.host_group]|length > 0 and ('HIVE_SERVER' in item.services or 'HIVE_METASTORE' in item.services or 'SPARK2_JOBHISTORYSERVER' in item.services)
           with_items: "{{ blueprint_dynamic }}"
           no_log: True
 
@@ -304,7 +304,7 @@
         - name: Populate the hiveserver hosts list
           set_fact:
             hiveserver_hosts: "{{ groups['hadoop-cluster'] }}"
-          when: blueprint_static['host_groups'] | string is search("HIVE_SERVER") or blueprint_static['host_groups'] | string is search("HIVE_METASTORE")
+          when: blueprint_static['host_groups'] | string is search("HIVE_SERVER") or blueprint_static['host_groups'] | string is search("HIVE_METASTORE") or blueprint_static['host_groups'] | string is search("SPARK2_JOBHISTORYSERVER")
 
         - name: Populate the oozie hosts list
           set_fact:


### PR DESCRIPTION
this fixes: spark2_historyserver startup fails in case it is on a different node that the hive2-metastore (or the hive-server itself)
Example error of the issue: <img width="1025" alt="spark2_historyserver startup fails-Screen Shot 2019-03-15 at 23 46 02" src="https://user-images.githubusercontent.com/3091244/54495568-07f94c80-48e5-11e9-9a1c-f8f598c9c7ce.png">
ps: Feel free to add another OR clause for the older (spark 1) historyserver
ps2: At some point we can refactor the multi or expression with a more comprehensive search/regex check (using `a|b|...` 