### PR TITLE
fix the superset username and password in the blueprint template

### DIFF
--- a/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
+++ b/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
@@ -643,8 +643,8 @@
         {% endif -%}
         "SUPERSET_DATABASE_HOSTNAME": "{{ database_options.external_hostname|default(ansible_fqdn,true) }}",
         "SUPERSET_DATABASE_NAME": "{{ database_options.superset_db_name }}",
-        "SUPERSET_DATABASE_USER": "{{ database_options.superset_db_name }}",
-        "SUPERSET_DATABASE_PASSWORD": "{{ database_options.superset_db_name }}",
+        "SUPERSET_DATABASE_USER": "{{ database_options.superset_db_username }}",
+        "SUPERSET_DATABASE_PASSWORD": "{{ database_options.superset_db_password }}",
         {% else -%}
         "SUPERSET_DATABASE_TYPE": "sqlite",
         "SUPERSET_DATABASE_HOSTNAME": "localhost",


### PR DESCRIPTION
Due to this bug, Superset will not startup after the installation when you configured a different password than the default.
The PR fixes this Bug.