### PR TITLE
Include inventory_to_use vars to add cluster's hosts in ambari_groups

### DIFF
--- a/install_cluster.sh
+++ b/install_cluster.sh
@@ -5,5 +5,5 @@ source $(dirname "${BASH_SOURCE[0]}")/set_inventory.sh
 
 ansible-playbook "playbooks/install_cluster.yml" \
                  --inventory="inventory/${inventory_to_use}" \
-                 --extra-vars="cloud_name=${cloud_to_use}" \
+                 --extra-vars="cloud_name=${cloud_to_use} inventory_to_use=${inventory_to_use}" \
                  "$@"

--- a/playbooks/set_variables.yml
+++ b/playbooks/set_variables.yml
@@ -12,6 +12,15 @@
       set_fact:
         ambari_groups: []
 
+    - name: Check inventory_to_use vars file
+      stat:
+        path: "group_vars/{{ inventory_to_use }}"
+      register: inventory_to_use_vars
+
+    - name: Include cluster vars
+      include_vars: "group_vars/{{ inventory_to_use }}"
+      when: inventory_to_use_vars.stat.exists == True
+
     - block:
         - name: Populate the ambari_groups list (dynamic blueprint)
           set_fact:


### PR DESCRIPTION
This change permit to create a file in vars that define the cluster by overriding some of the properties defined in 'all' file without modifying it.

For example, I create playbooks/group_vars/poc_cluster:
`---
cluster_name: 'poc_cluster'

ambari_admin_password: 'CapBdaas2019;'
default_password: 'CapBdaas2019;'

blueprint_dynamic:
  - host_group: "hdp-master"
    clients: ['ZOOKEEPER_CLIENT', 'HDFS_CLIENT', 'YARN_CLIENT', 'MAPREDUCE2_CLIENT', 'TEZ_CLIENT', 'PIG', 'SQOOP', 'HIVE_CLIENT', 'OOZIE_CLIENT', 'INFRA_SOLR_CLIENT', 'SPARK2_CLIENT', 'HBASE_CLIENT']
    services: ['NAMENODE', 'SECONDARY_NAMENODE', 'ZOOKEEPER_SERVER', 'KAFKA_BROKER', 'RESOURCEMANAGER', 'APP_TIMELINE_SERVER', 'YARN_REGISTRY_DNS', 'TIMELINE_READER', 'HISTORYSERVER', 'HIVE_SERVER', 'HIVE_METASTORE', 'OOZIE_SERVER', 'HBASE_MASTER', 'SPARK2_JOBHISTORYSERVER', 'ZEPPELIN_MASTER', 'AMBARI_SERVER', 'INFRA_SOLR', 'NIFI_REGISTRY_MASTER']

  - host_group: "hdp-slave"
    clients: ['ZOOKEEPER_CLIENT', 'HDFS_CLIENT', 'YARN_CLIENT', 'MAPREDUCE2_CLIENT', 'TEZ_CLIENT', 'PIG', 'SQOOP', 'HIVE_CLIENT', 'OOZIE_CLIENT', 'INFRA_SOLR_CLIENT', 'SPARK2_CLIENT', 'HBASE_CLIENT']
    services: ['DATANODE', 'NODEMANAGER', 'HBASE_REGIONSERVER', 'NIFI_MASTER']
`