### PR TITLE
livy2-env blueprint config supported only supported since HDP >=v2.6

### DIFF
--- a/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
+++ b/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
@@ -863,11 +863,13 @@
         "spark_log_dir" : "{{ base_log_dir }}/spark2"
       }
     },
+{% if hdp_minor_version is version_compare('2.6', '>=') %}
     {
       "livy2-env" : {
         "livy2_log_dir" : "{{ base_log_dir }}/livy2"
       }
     },
+{% endif %}
 {% endif %}
     {
       "tez-env" : {


### PR DESCRIPTION

Found this small Bug, when I tried to deploy a HDP 2.5.3 test cluster (planned to test an upgrade from 2.5.x to 2.6.x at a customer), but failed when sending the blueprint to Ambari, with error:
`InvalidTopologyException: The following config types are not defined in the stack: [livy2-env] `

Full task log from ansible:
```
TASK [ambari-blueprint : Launch the create cluster request] ************************************************************************************************************************
fatal: [ec2-34-216-152-196.us-west-2.compute.amazonaws.com]: FAILED! => {"cache_control": "no-store", "changed": false, "connection": "close", "content": "{\n  \"status\" : 400,\n  \"message\" : \"Topology validation failed: org.apache.ambari.server.topology.InvalidTopologyException: The following config types are not defined in the stack: [livy2-env] \"\n}", "content_type": "text/plain", "elapsed": 0, "expires": "Thu, 01 Jan 1970 00:00:00 GMT", "json": {"message": "Topology validation failed: org.apache.ambari.server.topology.InvalidTopologyException: The following config types are not defined in the stack: [livy2-env] ", "status": 400}, "msg": "Status code was 400 and not [200, 201, 202]: HTTP Error 400: Bad Request", "pragma": "no-cache", "redirected": false, "set_cookie": "AMBARISESSIONID=1jqvziwx8qxl550xfuwb6zvwg;Path=/;HttpOnly", "status": 400, "url": "http://ip-10-0-10-191.us-west-2.compute.internal:8080/api/v1/clusters/hdp253v1", "user": "admin", "x_content_type_options": "nosniff", "x_frame_options": "DENY", "x_xss_protection": "1; mode=block"}

```
