### PR TITLE
Initial Molecule tests (to deploy a single-node HDP3 cluster)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+---
+sudo: required
+
+language: python
+
+services:
+  - docker
+
+install:
+  # molecule version >v2.22 required for compatibility with ansible 2.8.x (provided in the used docker image)
+  - pip install molecule==2.22
+  - pip install docker
+script:
+  - molecule test
+  # TODO test 2nd scenario (multi-node !?)
+  #- molecule test --scenario-name xxx
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ services:
 install:
   # molecule version >v2.22 required for compatibility with ansible 2.8.x (provided in the used docker image)
   - pip install molecule==2.22
+  # Use ansible 2.8 due to issue in 2.9.0 in the blueprint role task setting the 'cluster_template' fact
+  # Related issue (most probably): https://github.com/ansible/ansible/issues/64169
+  - pip install ansible==2.8.2
   - pip install docker
 script:
   - molecule test

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -1,0 +1,22 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates iproute2 && xbps-remove -O; fi

--- a/molecule/default/INSTALL.rst
+++ b/molecule/default/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[docker]'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,18 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: instance
+    image: centos:7
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,9 +20,7 @@ platforms:
     command: "/usr/sbin/init"
     groups:
       - hadoop-cluster
-      - hdp-master
-      # TODO either use 2 nodes, or provide group_vars with 1-node blueprint !
-      #- hdp-slave
+      - hdp-singlenode
     networks:
       - name: molecule_hdp
     network_mode: bridge

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,7 +1,9 @@
 ---
 # Molecule config for a single-node HDP cluster
 #
-# TODO Try multi-node cluster (so we can use the 2-node master/slave blueprint in default group_vars/all)
+# Notes:
+# - Linters are set enabled=false because the roles currently contains many lint warnings
+# - The 'destroy' action is commented out to avoid accidentally destroying your molecule cluster
 #
 dependency:
   name: galaxy
@@ -9,12 +11,13 @@ driver:
   name: docker
 lint:
   name: yamllint
+  enabled: false
 # Using geerlingguy's image that provides centos7 with ansible AND systemd
 platforms:
   - name: "${MOLECULE_DISTRO:-centos7}-hdp01"
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
-    pre_build_image: True
-    privileged: True
+    pre_build_image: true
+    privileged: true
     volume_mounts:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     command: "/usr/sbin/init"
@@ -51,17 +54,17 @@ platforms:
 
 provisioner:
   name: ansible
+  enabled: false
   config_options:
     defaults:
       gathering: smart
       fact_caching: jsonfile
       fact_caching_connection: /tmp/facts_cache
     ssh_connection:
-      pipelining: True
-
+      pipelining: true
   options:
     diff: true
-    v: True
+    v: true
   inventory:
     group_vars:
       # Note: Need to use specific inventory group_vars here, since (due to vars precedence) inventory group_vars/all will be overriden by the playbook group_vars/all !
@@ -70,23 +73,25 @@ provisioner:
         cluster_name: 'cluster-name that wont be used since the var is overriden anyway by playbook group_vars'
       hadoop-cluster:
         cluster_name: 'cluster_name_overriden_by_import_playbook_vars'
-
+  # ansible-lint config
   lint:
     name: ansible-lint
+    enabled: false
+
 scenario:
   name: default
   test_sequence:
-    # - lint
-    #- destroy
+    - lint
+    # - destroy
     - dependency
     - syntax
     - create
     - prepare
     - converge
-    #- idempotence
+    # - idempotence
     # - side_effect
     - verify
-    #- destroy
+    # - destroy
 verifier:
   name: testinfra
   lint:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,17 +1,94 @@
 ---
+# Molecule config for a single-node HDP cluster
+#
+# TODO Try multi-node cluster (so we can use the 2-node master/slave blueprint in default group_vars/all)
+#
 dependency:
   name: galaxy
 driver:
   name: docker
 lint:
   name: yamllint
+# Using geerlingguy's image that provides centos7 with ansible AND systemd
 platforms:
-  - name: instance
-    image: centos:7
+  - name: "${MOLECULE_DISTRO:-centos7}-hdp01"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    pre_build_image: True
+    privileged: True
+    volume_mounts:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/usr/sbin/init"
+    groups:
+      - hadoop-cluster
+      - hdp-master
+      # TODO either use 2 nodes, or provide group_vars with 1-node blueprint !
+      #- hdp-slave
+    networks:
+      - name: molecule_hdp
+    network_mode: bridge
+    # Host networking did not work on my Macbook (it hang at task waiting for the Ambari Agents registration)
+    #network_mode: host
+    published_ports:
+      # Ambari
+      - 0.0.0.0:8080:8080/tcp
+      # YARN
+      - 0.0.0.0:8088:8088/tcp
+      # HDFS
+      - 0.0.0.0:50070:50070/tcp
+      - 0.0.0.0:50075:50075/tcp
+      # Spark-History
+      - 0.0.0.0:18081:18081/tcp
+      # Knox
+      - 0.0.0.0:8443:8443/tcp
+      # Zeppelin
+      - 0.0.0.0:9995:9995/tcp
+      # Ranger
+      - 0.0.0.0:6080:6080/tcp
+      # NiFi
+      - 0.0.0.0:9090:9090/tcp
+      # NiFi-Registry
+      - 0.0.0.0:18080:18080/tcp      
+    #Not needed:
+    #exposed_ports:
+
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      gathering: smart
+      fact_caching: jsonfile
+      fact_caching_connection: /tmp/facts_cache
+    ssh_connection:
+      pipelining: True
+
+  options:
+    diff: true
+    v: True
+  inventory:
+    group_vars:
+      # Note: Need to use specific inventory group_vars here, since (due to vars precedence) inventory group_vars/all will be overriden by the playbook group_vars/all !
+      # However we still need to use 'all' group_vars so that the 'set_variables.yml' playbook (running on host=localhost) can see them!
+      all:
+        cluster_name: 'cluster-name that wont be used since the var is overriden anyway by playbook group_vars'
+      hadoop-cluster:
+        cluster_name: 'cluster_name_overriden_by_import_playbook_vars'
+
   lint:
     name: ansible-lint
+scenario:
+  name: default
+  test_sequence:
+    # - lint
+    #- destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    #- idempotence
+    # - side_effect
+    - verify
+    #- destroy
 verifier:
   name: testinfra
   lint:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -6,9 +6,12 @@
 - name: Pre-reqs
   hosts: "localhost:all"
   vars:
-    blueprint_vars_file: example-hdp3-singlenode
+    ## Note: As travis provide only 7.5GB VMs, to get a working deployment (including started services started) you have to use a more minimal blueprint:
+    blueprint_vars_file: example-hdp3-singlenode-no-monitoring
+    ## Note: All below blueprints require ~12GB dedicated RAM
+    #blueprint_vars_file: example-hdp3-singlenode
     #blueprint_vars_file: example-hdp3-singlenode-with-nifi
-    # Note: To install Ranger, you need to set a non-embedded DB
+    ## Note: To install Ranger, you need to set a non-embedded DB
     #blueprint_vars_file: example-hdp3-singlenode-with-ranger-atlas
   tasks:
     - debug:
@@ -28,3 +31,5 @@
         cloud_name: static
         java: 'openjdk'
         ambari_version: '2.7.3.0'
+        # Currently postgres startup fails in database 'role' with error "Unable to start service postgresql-9.6"
+        #database: 'postgres'

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,12 +1,24 @@
 ---
+## Notes:
+# - deployment with blueprint playbooks/group_vars/example-hdp3-singlenode-with-nifi, hung during services startup with docker mem max at 9GB
+#
+# Important: Any variable overrides must be read not just for 'all' hosts, but also on 'localhost' (used in the set_variables.yml playbooks)
 - name: Pre-reqs
-  hosts: all
+  hosts: "localhost:all"
+  vars:
+    blueprint_vars_file: example-hdp3-singlenode
+    #blueprint_vars_file: example-hdp3-singlenode-with-nifi
+    # Note: To install Ranger, you need to set a non-embedded DB
+    #blueprint_vars_file: example-hdp3-singlenode-with-ranger-atlas
   tasks:
-    - name: checks
-      debug:
-        var: cloud_name
     - debug:
-        var: is_vm_docker_containers
+        var: cloud_name
+    - name: "load blueprint vars for the selected blueprint cfg file {{blueprint_vars_file}}"
+      include_vars: ../../playbooks/group_vars/{{blueprint_vars_file}}
+    - debug:
+        var: blueprint_dynamic
+        verbosity: 1
+          
 - name: Converge
   # Note: To override the repo's "playbook group_vars" it's easier to use a "vars:" block here, as inventory vars have lower precedence!
   # Note: Another reason for vars *here* is: the 'set_variables.yml' playbook runs on 'localhost', so only sees 'all' group_vars 
@@ -14,35 +26,5 @@
   vars:
         is_vm_docker_containers: "yes"
         cloud_name: static
-        java: 'openjdk'        
+        java: 'openjdk'
         ambari_version: '2.7.3.0'
-        blueprint_dynamic:
-          - host_group: "hdp-master"
-            clients: ['ZOOKEEPER_CLIENT', 'HDFS_CLIENT', 'YARN_CLIENT', 'MAPREDUCE2_CLIENT', 'TEZ_CLIENT', 'PIG', 'SQOOP', 'HIVE_CLIENT', 'OOZIE_CLIENT', 'INFRA_SOLR_CLIENT', 'SPARK2_CLIENT']
-            #clients: ['ZOOKEEPER_CLIENT', 'HDFS_CLIENT', 'YARN_CLIENT', 'MAPREDUCE2_CLIENT', 'TEZ_CLIENT', 'HIVE_CLIENT', 'SPARK2_CLIENT']
-            services:
-              - ZOOKEEPER_SERVER
-              - NAMENODE
-              - SECONDARY_NAMENODE
-              - RESOURCEMANAGER
-              - APP_TIMELINE_SERVER
-              - YARN_REGISTRY_DNS
-              - TIMELINE_READER
-              - HISTORYSERVER
-              - SPARK2_JOBHISTORYSERVER
-              - HIVE_SERVER
-              - HIVE_METASTORE
-              - OOZIE_SERVER
-              - KNOX_GATEWAY
-              - AMBARI_SERVER
-              - INFRA_SOLR
-              - METRICS_COLLECTOR
-              - METRICS_GRAFANA
-              - METRICS_MONITOR
-              - HST_SERVER
-              - ACTIVITY_ANALYZER
-              - ACTIVITY_EXPLORER
-              - HST_AGENT
-              - DATANODE
-              - NODEMANAGER
-              - METRICS_MONITOR

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,5 +1,48 @@
 ---
-- name: Converge
+- name: Pre-reqs
   hosts: all
-  roles:
-    - role: ansible-hortonworks
+  tasks:
+    - name: checks
+      debug:
+        var: cloud_name
+    - debug:
+        var: is_vm_docker_containers
+- name: Converge
+  # Note: To override the repo's "playbook group_vars" it's easier to use a "vars:" block here, as inventory vars have lower precedence!
+  # Note: Another reason for vars *here* is: the 'set_variables.yml' playbook runs on 'localhost', so only sees 'all' group_vars 
+  import_playbook: ../../playbooks/install_cluster.yml
+  vars:
+        is_vm_docker_containers: "yes"
+        cloud_name: static
+        java: 'openjdk'        
+        ambari_version: '2.7.3.0'
+        blueprint_dynamic:
+          - host_group: "hdp-master"
+            clients: ['ZOOKEEPER_CLIENT', 'HDFS_CLIENT', 'YARN_CLIENT', 'MAPREDUCE2_CLIENT', 'TEZ_CLIENT', 'PIG', 'SQOOP', 'HIVE_CLIENT', 'OOZIE_CLIENT', 'INFRA_SOLR_CLIENT', 'SPARK2_CLIENT']
+            #clients: ['ZOOKEEPER_CLIENT', 'HDFS_CLIENT', 'YARN_CLIENT', 'MAPREDUCE2_CLIENT', 'TEZ_CLIENT', 'HIVE_CLIENT', 'SPARK2_CLIENT']
+            services:
+              - ZOOKEEPER_SERVER
+              - NAMENODE
+              - SECONDARY_NAMENODE
+              - RESOURCEMANAGER
+              - APP_TIMELINE_SERVER
+              - YARN_REGISTRY_DNS
+              - TIMELINE_READER
+              - HISTORYSERVER
+              - SPARK2_JOBHISTORYSERVER
+              - HIVE_SERVER
+              - HIVE_METASTORE
+              - OOZIE_SERVER
+              - KNOX_GATEWAY
+              - AMBARI_SERVER
+              - INFRA_SOLR
+              - METRICS_COLLECTOR
+              - METRICS_GRAFANA
+              - METRICS_MONITOR
+              - HST_SERVER
+              - ACTIVITY_ANALYZER
+              - ACTIVITY_EXPLORER
+              - HST_AGENT
+              - DATANODE
+              - NODEMANAGER
+              - METRICS_MONITOR

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,0 +1,5 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: ansible-hortonworks

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -16,12 +16,12 @@
   tasks:
     - debug:
         var: cloud_name
-    - name: "load blueprint vars for the selected blueprint cfg file {{blueprint_vars_file}}"
-      include_vars: ../../playbooks/group_vars/{{blueprint_vars_file}}
+    - name: "load blueprint vars for the selected blueprint cfg file {{ blueprint_vars_file }}"
+      include_vars: ../../playbooks/group_vars/{{ blueprint_vars_file }}
     - debug:
         var: blueprint_dynamic
         verbosity: 1
-          
+
 - name: Converge
   # Note: To override the repo's "playbook group_vars" it's easier to use a "vars:" block here, as inventory vars have lower precedence!
   # Note: Another reason for vars *here* is: the 'set_variables.yml' playbook runs on 'localhost', so only sees 'all' group_vars 

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,0 +1,15 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_hosts_file(host):
+    f = host.file('/etc/hosts')
+
+    assert f.exists
+    assert f.user == 'root'
+    assert f.group == 'root'

--- a/playbooks/group_vars/example-hdp3-singlenode-no-monitoring
+++ b/playbooks/group_vars/example-hdp3-singlenode-no-monitoring
@@ -1,0 +1,33 @@
+###########
+# Blueprint derived from "example-hdp3-singlenode" but without components: HST*,METRICS*, OOZIE, HBASE*, KNOX
+#
+# These variables would be used by the 'blueprint_dynamic.j2' Jinja2 template to generate the blueprint JSON.
+# This blueprint will build a single node HDP instance with Ambari and some of the more common services.
+#
+###########
+
+blueprint_name: '{{ cluster_name }}_blueprint'                  # the name of the blueprint as it will be stored in Ambari
+blueprint_file: 'blueprint_dynamic.j2'                          # the blueprint JSON file - 'blueprint_dynamic.j2' is a Jinja2 template that generates the required JSON
+blueprint_dynamic:                                              # properties for the dynamic blueprint - these are only used by the 'blueprint_dynamic.j2' template to generate the JSON
+  - host_group: "hdp-singlenode"
+    #clients: ['ZOOKEEPER_CLIENT', 'HDFS_CLIENT', 'YARN_CLIENT', 'MAPREDUCE2_CLIENT', 'TEZ_CLIENT', 'PIG', 'SQOOP', 'HIVE_CLIENT', 'SPARK2_CLIENT', 'HBASE_CLIENT']
+    clients: ['ZOOKEEPER_CLIENT', 'HDFS_CLIENT', 'YARN_CLIENT', 'MAPREDUCE2_CLIENT', 'TEZ_CLIENT', 'PIG', 'SQOOP', 'HIVE_CLIENT', 'SPARK2_CLIENT']
+    services:
+      - AMBARI_SERVER
+      - ZOOKEEPER_SERVER
+      - NAMENODE
+      - SECONDARY_NAMENODE
+      - DATANODE
+      - RESOURCEMANAGER
+      - NODEMANAGER
+      - APP_TIMELINE_SERVER
+      - YARN_REGISTRY_DNS
+      - TIMELINE_READER
+      - HISTORYSERVER
+      - HIVE_SERVER
+      - HIVE_METASTORE
+      # - HBASE_MASTER
+      # - HBASE_REGIONSERVER
+      - SPARK2_JOBHISTORYSERVER
+      - ZEPPELIN_MASTER
+      # - KNOX_GATEWAY


### PR DESCRIPTION

Current state:
* 2019-10-04: Initial POC of molecule tests (done in <2h), already got a working deployment of the full playbook incl. the blueprint deployment
  * single node (host_group=hdp_master)
* 2019-10-11: Improvements including a working travis build
  * feature/var allowing to easily switch the example blueprint configs (available in the `playbook/group_vars` folder)
  * required multiple build tries, and a slimmed down blueprint, since (free) Travis VMs are limited to 7.5GB RAM: https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system
* 2019-11-08: fixed build that broke with recent ansible 2.9.0 release:
  >  Use ansible 2.8 due to issue in 2.9.0 in the blueprint role task setting the 'cluster_template' fact. Related ansible issue (most probably): https://github.com/ansible/ansible/issues/64169

Next steps:
* Enable travis in the upstream repo (here) .. @alexandruanghel !?
  * See a working travis build in action in: https://github.com/scigility/ansible-hortonworks/pull/3
* basic `testinfra` checks (p.eg checking via AMBARI REST API that services and hosts are healthy and running)
* add more test scenarios:
  * try multi nodes/containers clusters (though it will get difficult to get such builds working on travis, unless the blueprint is very minimal)
  * test with various HDP/HDF versions
  * test with various OSes (not just centos7, also Ubuntu, Suse !?)